### PR TITLE
ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debug/data/hsa.json
 debug/data/zips*.json
 geojson-vt-dev.js
 geojson-vt.js
+node_modules


### PR DESCRIPTION
Maintainer probably has them in core.excludesfile, but not everyone (e.g. me) is that smart.
