### PR TITLE
Expose interface to create single tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ var tileIndex = geojsonvt(data, {
 });
 ```
 
+### Usage: Single Tile
+
+Alternatively, you can make a single tile directly:
+
+```js
+var tile = geojsonvt.createTile(geoJSON, z, x, y);
+
+// get features
+var features = tile.features
+```
+
+`createTile` takes an optional options object as the last parameter,
+respecting `buffer`, `tolerance`, and `extent` exactly as described above, and
+using the same defaults:
+
+```js
+var tiles = geojsonvt.createTile(geoJSON, z, x, y, {
+  tolerance: 3,
+  extent: 4096,
+  buffer: 64
+});
+```
+
 ### Browser builds
 
 ```bash

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,44 @@
+'use strict';
+
+module.exports = {
+    tile: transformTile,
+    point: transformPoint
+};
+
+// Transforms the coordinates of each feature in the given tile from
+// mercator-projected space into (extent x extent) tile space.
+function transformTile(tile, extent) {
+    if (tile.transformed) return tile;
+
+    var z2 = tile.z2,
+        tx = tile.x,
+        ty = tile.y,
+        i, j, k;
+
+    for (i = 0; i < tile.features.length; i++) {
+        var feature = tile.features[i],
+            geom = feature.geometry,
+            type = feature.type;
+
+        if (type === 1) {
+            for (j = 0; j < geom.length; j++) geom[j] = transformPoint(geom[j], extent, z2, tx, ty);
+
+        } else {
+            for (j = 0; j < geom.length; j++) {
+                var ring = geom[j];
+                for (k = 0; k < ring.length; k++) ring[k] = transformPoint(ring[k], extent, z2, tx, ty);
+            }
+        }
+    }
+
+    tile.transformed = true;
+
+    return tile;
+}
+
+function transformPoint(p, extent, z2, tx, ty) {
+    var x = Math.round(extent * (p[0] * z2 - tx)),
+        y = Math.round(extent * (p[1] * z2 - ty));
+    return [x, y];
+}
+

--- a/test/test-single-tile.js
+++ b/test/test-single-tile.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+
+var geojsonvt = require('../');
+
+test('create a single tile', function (t) {
+    var data = getJSON('feature.json');
+    var tile = geojsonvt.createTile(data, 0, 0, 0, {});
+    t.same(tile.features, getJSON('feature-tiles.json')['z0-0-0']);
+    t.end();
+});
+
+test('consistent with with full-index tiles', function (t) {
+    var data = getJSON('feature.json');
+    // use a tile that will result in some clipping here:
+    var tile = geojsonvt.createTile(data, 1, 1, 0, {});
+    // get the equivalent one from a normal geojson-vt index:
+    var fromIndex = geojsonvt(data, {}).getTile(1, 1, 0);
+    delete tile.source;
+    delete fromIndex.source;
+    t.same(tile, fromIndex);
+    t.end();
+});
+
+function getJSON(name) {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '/fixtures/' + name)));
+}


### PR DESCRIPTION
 - [x] expose transformTile, transformPoint via a sub module (separate file)
 - [x] add `createSingleTile` ( Closes #43 )

Questions:
1. Preferred way to expose `createSingleTile`?  I guess my inclination would be to make it into its own file in `lib/`, rather than confusing the main module with it. 
2. Should `createSingleTile` clip features according to a buffer option?  Not necessary for my use case, but maybe this makes it more useful in general?
