### PR TITLE
ignore features with null geometry

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -24,6 +24,11 @@ function convert(data, tolerance) {
 }
 
 function convertFeature(features, feature, tolerance) {
+    if (feature.geometry === null) {
+        // ignore features with null geometry
+        return;
+    }
+
     var geom = feature.geometry,
         type = geom.type,
         coords = geom.coordinates,

--- a/test/fixtures/feature-null-geometry.json
+++ b/test/fixtures/feature-null-geometry.json
@@ -1,0 +1,7 @@
+{ "type": "Feature",
+ "geometry": null,
+ "properties": {
+   "prop0": "value0",
+   "prop1": {"this": "that"}
+   }
+ }

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -31,6 +31,12 @@ test('empty geojson', function (t) {
     t.end();
 });
 
+test('null geometry', function (t) {
+    // should ignore features with null geometry
+    t.same({}, genTiles(getJSON('feature-null-geometry.json')));
+    t.end();
+});
+
 function getJSON(name) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, '/fixtures/' + name)));
 }


### PR DESCRIPTION
As per the GeoJSON spec, "A feature object must have a member with
the name "geometry". The value of the geometry member is a geometry
object as defined above or a JSON null value." [1]

[1] http://geojson.org/geojson-spec.html#feature-objects

Previously when there was a null geometry there would be a JS error
in trying to access feature.geometry.type.