### PR TITLE
add outer in the simplified polygon geometry

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -72,9 +72,9 @@ function addFeature(tile, feature, tolerance, noSimplify) {
             }
 
              if (type === 3) {
-                rewind(simplifiedRing, ring.outer);
-                simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
-            }
+                 rewind(simplifiedRing, ring.outer);
+                 simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
+             }
 
             simplified.push(simplifiedRing);
         }

--- a/src/tile.js
+++ b/src/tile.js
@@ -71,7 +71,7 @@ function addFeature(tile, feature, tolerance, noSimplify) {
                 tile.numPoints++;
             }
 
-             if (type === 3) {
+            if (type === 3) {
                  rewind(simplifiedRing, ring.outer);
                  simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
              }

--- a/src/tile.js
+++ b/src/tile.js
@@ -71,7 +71,10 @@ function addFeature(tile, feature, tolerance, noSimplify) {
                 tile.numPoints++;
             }
 
-            if (type === 3) rewind(simplifiedRing, ring.outer);
+             if (type === 3) {
+                rewind(simplifiedRing, ring.outer);
+                simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
+            }
 
             simplified.push(simplifiedRing);
         }

--- a/src/tile.js
+++ b/src/tile.js
@@ -72,9 +72,9 @@ function addFeature(tile, feature, tolerance, noSimplify) {
             }
 
             if (type === 3) {
-                 rewind(simplifiedRing, ring.outer);
-                 simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
-             }
+                rewind(simplifiedRing, ring.outer);
+                simplifiedRing.outer = ring.outer; // -- keep the info about outer in the simplified ring
+            }
 
             simplified.push(simplifiedRing);
         }


### PR DESCRIPTION
outer was missing in the resulting tile geometry for polygons (type ===3), for multipolygons with holes it was impossible to determine coordinates belonging to either outer or inner polygon.