### PR TITLE
Fixed missing comma in README options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var tileIndex = geojsonvt(data, {
 	tolerance: 3, // simplification tolerance (higher means simpler)
 	extent: 4096, // tile extent (both width and height)
 	buffer: 64,	  // tile buffer on each side
-	debug: 0      // logging level (0 to disable, 1 or 2)
+	debug: 0,      // logging level (0 to disable, 1 or 2)
 
 	indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000 // max number of points per tile in the index


### PR DESCRIPTION
The missing comma within the object literal would cause copy-and-pasting the example to throw a syntax error.