### PR TITLE
use https for external libraries in debug page

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -16,7 +16,7 @@
 
 <body>
     <script src='../geojson-vt-dev.js'></script>
-    <script src="http://d3js.org/topojson.v1.min.js"></script>
+    <script src="https://d3js.org/topojson.v1.min.js"></script>
     <canvas id="canvas"></canvas>
     <button id="back">&larr;</button>
     <script src="viz.js"></script>


### PR DESCRIPTION
Fixes `Mixed Content: The page at 'https://mapbox.github.io/geojson-vt/debug/' was loaded over HTTPS, but requested an insecure script 'http://d3js.org/topojson.v1.min.js'. This request has been blocked; the content must be served over HTTPS.`