### PR TITLE
With buffer: 0, geometry coincident with a tile edge is clipped inconsistently

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^4.18.2",
     "eslint-config-mourner": "^2.0.3",
-    "esm": "^3.0.11",
+    "esm": "^3.0.19",
     "nyc": "^11.4.1",
     "rollup": "^0.57.1",
     "rollup-plugin-uglify": "^3.0.0",

--- a/src/clip.js
+++ b/src/clip.js
@@ -13,8 +13,8 @@ export default function clip(features, scale, k1, k2, axis, minAll, maxAll, opti
     k1 /= scale;
     k2 /= scale;
 
-    if (minAll >= k1 && maxAll <= k2) return features; // trivial accept
-    else if (minAll > k2 || maxAll < k1) return null; // trivial reject
+    if (minAll >= k1 && maxAll < k2) return features; // trivial accept
+    else if (maxAll < k1 || minAll >= k2) return null; // trivial reject
 
     var clipped = [];
 
@@ -27,10 +27,10 @@ export default function clip(features, scale, k1, k2, axis, minAll, maxAll, opti
         var min = axis === 0 ? feature.minX : feature.minY;
         var max = axis === 0 ? feature.maxX : feature.maxY;
 
-        if (min >= k1 && max <= k2) { // trivial accept
+        if (min >= k1 && max < k2) { // trivial accept
             clipped.push(feature);
             continue;
-        } else if (min > k2 || max < k1) { // trivial reject
+        } else if (max < k1 || min >= k2) { // trivial reject
             continue;
         }
 
@@ -122,9 +122,9 @@ function clipLine(geom, newGeom, k1, k2, axis, isPolygon, trackMetrics) {
                 t = intersect(slice, ax, ay, bx, by, k1);
                 if (trackMetrics) slice.start = len + segLen * t;
             }
-        } else if (a > k2) {
+        } else if (a >= k2) {
             // |  <--|--- (line enters the clip region from the right)
-            if (b <= k2) {
+            if (b < k2) {
                 t = intersect(slice, ax, ay, bx, by, k2);
                 if (trackMetrics) slice.start = len + segLen * t;
             }

--- a/test/test-get-tile.js
+++ b/test/test-get-tile.js
@@ -17,8 +17,6 @@ test('getTile: us-states.json', function (t) {
     console.log = function () {};
     var index = geojsonvt(getJSON('us-states.json'), {debug: 2});
 
-    console.log = log;
-
     t.same(index.getTile(7, 37, 48).features, getJSON('us-states-z7-37-48.json'), 'z7-37-48');
 
     t.same(index.getTile(9, 148, 192).features, square, 'z9-148-192 (clipped square)');
@@ -27,6 +25,8 @@ test('getTile: us-states.json', function (t) {
     t.equal(index.getTile(11, 800, 400), null, 'non-existing tile');
     t.equal(index.getTile(-5, 123.25, 400.25), null, 'invalid tile');
     t.equal(index.getTile(25, 200, 200), null, 'invalid tile');
+
+    console.log = log;
 
     t.equal(index.total, 37);
 
@@ -41,7 +41,7 @@ test('getTile: unbuffered tile left/right edges', function (t) {
         buffer: 0
     });
 
-    t.same(index.getTile(2, 1, 1).features, [{geometry: [[[4096, 0], [4096, 4096]]], type: 2, tags: null}]);
+    t.same(index.getTile(2, 1, 1), null);
     t.same(index.getTile(2, 2, 1).features, [{geometry: [[[0, 0], [0, 4096]]], type: 2, tags: null}]);
     t.end();
 });
@@ -55,7 +55,7 @@ test('getTile: unbuffered tile top/bottom edges', function (t) {
     });
 
     t.same(index.getTile(2, 1, 0).features, [{geometry: [[[0, 4096], [4096, 4096]]], type: 2, tags: null}]);
-    t.same(index.getTile(2, 1, 1).features, [{geometry: [[[0, 0], [4096, 0]]], type: 2, tags: null}]);
+    t.same(index.getTile(2, 1, 1).features, []);
     t.end();
 });
 

--- a/test/test-get-tile.js
+++ b/test/test-get-tile.js
@@ -33,6 +33,32 @@ test('getTile: us-states.json', function (t) {
     t.end();
 });
 
+test('getTile: unbuffered tile left/right edges', function (t) {
+    var index = geojsonvt({
+        type: 'LineString',
+        coordinates: [[0, 90], [0, -90]]
+    }, {
+        buffer: 0
+    });
+
+    t.same(index.getTile(2, 1, 1).features, [{geometry: [[[4096, 0], [4096, 4096]]], type: 2, tags: null}]);
+    t.same(index.getTile(2, 2, 1).features, [{geometry: [[[0, 0], [0, 4096]]], type: 2, tags: null}]);
+    t.end();
+});
+
+test('getTile: unbuffered tile top/bottom edges', function (t) {
+    var index = geojsonvt({
+        type: 'LineString',
+        coordinates: [[-90, 66.51326044311188], [90, 66.51326044311188]]
+    }, {
+        buffer: 0
+    });
+
+    t.same(index.getTile(2, 1, 0).features, [{geometry: [[[0, 4096], [4096, 4096]]], type: 2, tags: null}]);
+    t.same(index.getTile(2, 1, 1).features, [{geometry: [[[0, 0], [4096, 0]]], type: 2, tags: null}]);
+    t.end();
+});
+
 function getJSON(name) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, '/fixtures/' + name)));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,9 +1171,9 @@ eslint@^4.18.2:
     table "4.0.2"
     text-table "~0.2.0"
 
-esm@^3.0.11:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.11.tgz#223baf6b5ab6956efbec6e554e8af1824145d160"
+esm@^3.0.19:
+  version "3.0.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.25.tgz#d374e714c07abe0b8a7e80d18819e5823e491dbd"
 
 espree@^3.5.4:
   version "3.5.4"


### PR DESCRIPTION
When using geojson-vt to generate bufferless tiles, a LineString geometry that is coincident with a tile edge is clipped inconsistently:

* LineString geometry that is coincident with a horizontal (top/bottom) tile edge appears only in the top tile (along its bottom edge).
* LineString geometry that is coincident with a vertical (left/right) tile edge appears in both tiles that share that edge.

It should be consistent one way or the other -- although possibly different from either of these two behaviors. For bufferless tiles in VT3, we're thinking of formally specifying that tiles are effectively inclusive of their top and left edges, and exclusive of their bottom and right edges, such that the correct behavior in this case is to include this type of coincident geometry in only the bottom and right tiles.

cc @mourner @anandthakker 