### PR TITLE
Åuto-generation and promotion options for Feature Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ var tileIndex = geojsonvt(data, {
 	extent: 4096, // tile extent (both width and height)
 	buffer: 64,	  // tile buffer on each side
 	debug: 0,      // logging level (0 to disable, 1 or 2)
-	lineMetrics: false,  // whether to enable line metrics tracking for LineString/MultiLineString features
-	promoteId: null,       // name of a feature property to promote to feature.id
-	indexMaxZoom: 5,       // max zoom in the initial tile index
+	lineMetrics: false, // whether to enable line metrics tracking for LineString/MultiLineString features
+	promoteId: null,    // name of a feature property to promote to feature.id. Cannot be used with `generateId`
+    generateId: false,  // whether to generate feature ids. Cannot be used with `promoteId`
+    indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000 // max number of points per tile in the index
 });
 ```
 
 By default, tiles at zoom levels above `indexMaxZoom` are generated on the fly, but you can pre-generate all possible tiles for `data` by setting `indexMaxZoom` and `maxZoom` to the same value, setting `indexMaxPoints` to `0`, and then accessing the resulting tile coordinates from the `tileCoords` property of `tileIndex`.
+
+The `promoteId` and `generateId` options ignore existing `id` values on the feature objects.
 
 GeoJSON-VT only operates on zoom levels up to 24.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ var tileIndex = geojsonvt(data, {
 	buffer: 64,	  // tile buffer on each side
 	debug: 0,      // logging level (0 to disable, 1 or 2)
 	lineMetrics: false,  // whether to enable line metrics tracking for LineString/MultiLineString features
-
+	promoteId: null,       // name of a feature property to promote to feature.id
 	indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000 // max number of points per tile in the index
 });

--- a/src/convert.js
+++ b/src/convert.js
@@ -30,7 +30,10 @@ function convertFeature(features, geojson, options) {
     var type = geojson.geometry.type;
     var tolerance = Math.pow(options.tolerance / ((1 << options.maxZoom) * options.extent), 2);
     var geometry = [];
-
+    var id = geojson.id;
+    if (options.promoteId) {
+        id = geojson.properties[options.promoteId];
+    }
     if (type === 'Point') {
         convertPoint(coords, geometry);
 
@@ -48,7 +51,7 @@ function convertFeature(features, geojson, options) {
             for (i = 0; i < coords.length; i++) {
                 geometry = [];
                 convertLine(coords[i], geometry, tolerance, false);
-                features.push(createFeature(geojson.id, 'LineString', geometry, geojson.properties));
+                features.push(createFeature(id, 'LineString', geometry, geojson.properties));
             }
             return;
         } else {
@@ -67,7 +70,7 @@ function convertFeature(features, geojson, options) {
     } else if (type === 'GeometryCollection') {
         for (i = 0; i < geojson.geometry.geometries.length; i++) {
             convertFeature(features, {
-                id: geojson.id,
+                id: id,
                 geometry: geojson.geometry.geometries[i],
                 properties: geojson.properties
             }, options);
@@ -77,7 +80,7 @@ function convertFeature(features, geojson, options) {
         throw new Error('Input data is not a valid GeoJSON object.');
     }
 
-    features.push(createFeature(geojson.id, type, geometry, geojson.properties));
+    features.push(createFeature(id, type, geometry, geojson.properties));
 }
 
 function convertPoint(coords, out) {

--- a/src/convert.js
+++ b/src/convert.js
@@ -6,10 +6,9 @@ import createFeature from './feature';
 
 export default function convert(data, options) {
     var features = [];
-
     if (data.type === 'FeatureCollection') {
         for (var i = 0; i < data.features.length; i++) {
-            convertFeature(features, data.features[i], options);
+            convertFeature(features, data.features[i], options, i);
         }
 
     } else if (data.type === 'Feature') {
@@ -23,7 +22,7 @@ export default function convert(data, options) {
     return features;
 }
 
-function convertFeature(features, geojson, options) {
+function convertFeature(features, geojson, options, index) {
     if (!geojson.geometry) return;
 
     var coords = geojson.geometry.coordinates;
@@ -33,6 +32,8 @@ function convertFeature(features, geojson, options) {
     var id = geojson.id;
     if (options.promoteId) {
         id = geojson.properties[options.promoteId];
+    } else if (options.generateId) {
+        id = index || 0;
     }
     if (type === 'Point') {
         convertPoint(coords, geometry);

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ GeoJSONVT.prototype.options = {
     extent: 4096,           // tile extent
     buffer: 64,             // tile buffer on each side
     lineMetrics: false,     // whether to calculate line metrics
+    promoteId: null,        // name of a feature property to be promoted to feature.id
     debug: 0                // logging level (0, 1 or 2)
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ function GeoJSONVT(data, options) {
     if (debug) console.time('preprocess data');
 
     if (options.maxZoom < 0 || options.maxZoom > 24) throw new Error('maxZoom should be in the 0-24 range');
+    if (options.promoteId && options.generateId) throw new Error('promoteId and generateId cannot be used together.');
 
     var features = convert(data, options);
 
@@ -52,6 +53,7 @@ GeoJSONVT.prototype.options = {
     buffer: 64,             // tile buffer on each side
     lineMetrics: false,     // whether to calculate line metrics
     promoteId: null,        // name of a feature property to be promoted to feature.id
+    generateId: false,      // whether to generate feature ids. Cannot be used with promoteId
     debug: 0                // logging level (0, 1 or 2)
 };
 

--- a/test/fixtures/ids.json
+++ b/test/fixtures/ids.json
@@ -1,0 +1,59 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+        {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [100.0, 0.0]
+            },
+            "properties": {
+              "prop0": "value0",
+              "prop1": {"this": "that"}
+            },
+            "id": 0
+        }, {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [100.0, 0.0]
+            },
+            "properties": {
+              "prop0": "1",
+              "prop1": {"this": "that"}
+            },
+            "id": "guid"
+        }, {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [100.0, 0.0]
+            },
+            "properties": {
+              "prop0": 1,
+              "prop1": {"this": "that"}
+            }
+        }, {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [100.0, 0.0]
+            },
+            "properties": {
+              "prop0": 1,
+              "prop1": {"this": "that"}
+            },
+            "id": 2
+        }, {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [100.0, 0.0]
+            },
+            "properties": {
+              "prop0": 2,
+              "prop1": {"this": "that"}
+            }
+        }        
+    ]
+}   

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -51,6 +51,19 @@ test('promote ids', function (t) {
     t.end();
 });
 
+test('generate ids', function (t) {
+    const data = getJSON('ids.json');
+    const tileIndex = geojsonvt(data, {
+        generateId: true,
+        indexMaxZoom: 0
+    });
+    const features = tileIndex.getTile(0, 0, 0).features;
+    for (let i = 0; i < features.length; i++) {
+        t.same(i, features[i].id);
+    }
+    t.end();
+});
+
 function getJSON(name) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, '/fixtures/' + name)));
 }

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -38,6 +38,19 @@ test('null geometry', function (t) {
     t.end();
 });
 
+test('promote ids', function (t) {
+    const data = getJSON('ids.json');
+    const tileIndex = geojsonvt(data, {
+        promoteId: 'prop0',
+        indexMaxZoom: 0
+    });
+    const features = tileIndex.getTile(0, 0, 0).features;
+    features.forEach((f) => {
+        t.same(f.tags.prop0, f.id);
+    });
+    t.end();
+});
+
 function getJSON(name) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, '/fixtures/' + name)));
 }


### PR DESCRIPTION
This PR adds two options for assigning ids to features - `promoteId` and `generateId`. Both options will ignore and replace the existing `id` field on features. This options can be used to consistently populate the `feautre.id` for GeoJSON data. 

#### `promoteId`

This option allows promoting a named feature property to be used as the `id` value. Useful when the existing data already includes unique identifiers in the feature data.
<details>
<summary> Example </summary>
Setting `promoteId: "guid"` would convert 
``` 
{ 
  "type": "Feature",
  "id": 0 
  "geometry": {
    "type": "Point",
    "coordinates": [ 0, 0]
  },
  "properties": {
    "guid": 12345,
    "prop1": {"this": "that"}
  }
}
```
 to 
```
{
  "id": 12345,
  "type":1,
  "geometry":[0, 0],
  "tags":{"guid":12345,"prop1":{"this":"that"}}
}
```
</details>



#### `generateId`

When the existing data does not have any id-like properties, this option can be used to auto assign the feature id using the feature's index in the `features` array of a `FeatureCollection`.

<details>
<summary> Example </summary>
Enabling `generateId: true` would for example convert 
``` 
{
  "type": "FeatureCollection",
  "features": [
  {...},   //index 0
  {...},   //          1
  {        //          2
    "type": "Feature",
    "id": 0 
    "geometry": {
      "type": "Point",
      "coordinates": [ 0, 0]
    },
    "properties": {
      "guid": 12345,
      "prop1": {"this": "that"}
    }
  }
]
}
```
 to 
```
{
  "id": 2,
  "type":1,
  "geometry":[0, 0],
  "tags":{"guid":12345,"prop1":{"this":"that"}}
}
```
</details>

cc @ryanbaumann 