### PR TITLE
Plate Carrée support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ var tileIndex = geojsonvt(data, {
 	generateId: false,  // whether to generate feature ids. Cannot be used with `promoteId`
 	indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000 // max number of points per tile in the index
-	projectPoint: defaultProjectPoint // allow a custom projection function
+	projectX: defaultX // allow a custom projection function
+	projectY: defaultY // allow a custom projection function
 });
 ```
 
@@ -73,13 +74,16 @@ The `promoteId` and `generateId` options ignore existing `id` values on the feat
 
 GeoJSON-VT only operates on zoom levels up to 24.
 
-This custom projection function will work with OpenLayers and Plate Carrée projection (it works by creating a bigger level 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180)
+Not all projections can be represented with the current model. They must be compatible with the tile division algorithm and the fact that the map is composed of a single square tile at zoom level 0. For example, this custom projection function will implement Plate Carrée projection (it works by creating a bigger zoom 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180).
 
 ```js
-function olPlateCarree(p) {
-	const x = (p[0] / 360) + 0.5;
-	const y = -(p[1] / 360) + 0.5;
-	return [x, y, 0];
+function olPlateCarreeX(p) {
+	const x = (p / 360) + 0.5;
+	return x;
+}
+function olPlateCarreeY(p) {
+	const y = -(p / 360) + 0.5;
+	return y;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ var tileIndex = geojsonvt(data, {
 	generateId: false,  // whether to generate feature ids. Cannot be used with `promoteId`
 	indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000 // max number of points per tile in the index
+	projectPoint: defaultProjectPoint // allow a custom projection function
 });
 ```
 
@@ -72,6 +73,13 @@ By default, tiles at zoom levels above `indexMaxZoom` are generated on the fly, 
 The `promoteId` and `generateId` options ignore existing `id` values on the feature objects.
 
 GeoJSON-VT only operates on zoom levels up to 24.
+
+This custom projection function will work with OpenLayers and Plate Carrée projection (it works by creating a bigger level 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180)
+function olPlateCarree(p) {
+	const x = (p[0] / 360) + 0.5;
+	const y = -(p[1] / 360) + 0.5;
+	return [x, y, 0];
+}
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var tileIndex = geojsonvt(data, {
 	generateId: false,  // whether to generate feature ids. Cannot be used with `promoteId`
 	indexMaxZoom: 5,       // max zoom in the initial tile index
 	indexMaxPoints: 100000, // max number of points per tile in the index
-	projectX: defaultX // allow a custom X projection function
+	projectX: defaultX, // allow a custom X projection function
 	projectY: defaultY // allow a custom Y projection function
 });
 ```
@@ -79,12 +79,13 @@ GeoJSON-VT only operates on zoom levels up to 24.
 Not all projections can be represented with the current model. They must be compatible with the tile division algorithm and the fact that the map is composed of a single square tile at zoom level 0. For example, this custom projection function will implement Plate Carrée projection (it works by creating a bigger zoom 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180).
 
 ```js
+// For EPSG:4326
 function olPlateCarreeX(p) {
 	const x = (p / 360) + 0.5;
 	return x;
 }
 function olPlateCarreeY(p) {
-	const y = -(p / 360) + 0.5;
+	const y = 0.25 - (p / 360);
 	return y;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ var tileIndex = geojsonvt(data, {
 	promoteId: null,    // name of a feature property to promote to feature.id. Cannot be used with `generateId`
 	generateId: false,  // whether to generate feature ids. Cannot be used with `promoteId`
 	indexMaxZoom: 5,       // max zoom in the initial tile index
-	indexMaxPoints: 100000 // max number of points per tile in the index
-	projectX: defaultX // allow a custom projection function
-	projectY: defaultY // allow a custom projection function
+	indexMaxPoints: 100000, // max number of points per tile in the index
+	projectX: defaultX // allow a custom X projection function
+	projectY: defaultY // allow a custom Y projection function
 });
 ```
 
@@ -73,6 +73,8 @@ By default, tiles at zoom levels above `indexMaxZoom` are generated on the fly, 
 The `promoteId` and `generateId` options ignore existing `id` values on the feature objects.
 
 GeoJSON-VT only operates on zoom levels up to 24.
+
+#### Custom projections
 
 Not all projections can be represented with the current model. They must be compatible with the tile division algorithm and the fact that the map is composed of a single square tile at zoom level 0. For example, this custom projection function will implement Plate Carrée projection (it works by creating a bigger zoom 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180).
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ The `promoteId` and `generateId` options ignore existing `id` values on the feat
 GeoJSON-VT only operates on zoom levels up to 24.
 
 This custom projection function will work with OpenLayers and Plate Carrée projection (it works by creating a bigger level 0 tile that has empty strips above the north pole and below the south pole) and then offseting the zoom level by one (thus the division by 360 and not 180)
+
+```js
 function olPlateCarree(p) {
 	const x = (p[0] / 360) + 0.5;
 	const y = -(p[1] / 360) + 0.5;
 	return [x, y, 0];
 }
+```
 
 ### Install
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -93,8 +93,8 @@ function convertLine(ring, out, tolerance, isPolygon, options) {
     let x0, y0;
     let size = 0;
 
-	for (let j = 0; j < ring.length; j++) {
-		const coords = options.projectPoint(ring[j]);
+    for (let j = 0; j < ring.length; j++) {
+        const coords = options.projectPoint(ring[j]);
         const x = coords[0];
         const y = coords[1];
 
@@ -130,8 +130,8 @@ function convertLines(rings, out, tolerance, isPolygon, options) {
 }
 
 export function defaultProjectPoint(coords) {
-	const x = coords[0] / 360 + 0.5
-	const sin = Math.sin(coords[1] * Math.PI / 180);
-	const y2 = 0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI;
-	return [x, y2 < 0 ? 0 : y2 > 1 ? 1 : y2];
+    const x = coords[0] / 360 + 0.5
+    const sin = Math.sin(coords[1] * Math.PI / 180);
+    const y2 = 0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI;
+    return [x, y2 < 0 ? 0 : y2 > 1 ? 1 : y2];
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -85,8 +85,7 @@ function convertFeature(features, geojson, options, index) {
 }
 
 function convertPoint(coords, out, options) {
-    const pcoords = options.projectPoint(coords);
-    out.push(pcoords[0], pcoords[1], 0);
+    out.push(options.projectX(coords[0]), options.projectY(coords[1]), 0);
 }
 
 function convertLine(ring, out, tolerance, isPolygon, options) {
@@ -94,9 +93,8 @@ function convertLine(ring, out, tolerance, isPolygon, options) {
     let size = 0;
 
     for (let j = 0; j < ring.length; j++) {
-        const coords = options.projectPoint(ring[j]);
-        const x = coords[0];
-        const y = coords[1];
+        const x = options.projectX(ring[j][0]);
+        const y = options.projectY(ring[j][1]);
 
         out.push(x, y, 0);
 
@@ -129,9 +127,12 @@ function convertLines(rings, out, tolerance, isPolygon, options) {
     }
 }
 
-export function defaultProjectPoint(coords) {
-    const x = coords[0] / 360 + 0.5
-    const sin = Math.sin(coords[1] * Math.PI / 180);
+export function defaultX(x) {
+    return x / 360 + 0.5;
+}
+
+export function defaultY(y) {
+    const sin = Math.sin(y * Math.PI / 180);
     const y2 = 0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI;
-    return [x, y2 < 0 ? 0 : y2 > 1 ? 1 : y2];
+    return y2 < 0 ? 0 : y2 > 1 ? 1 : y2;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 
-import { convert, defaultProjectPoint } from './convert.js'; // GeoJSON conversion and preprocessing
+import convert, { defaultProjectPoint } from './convert.js'; // GeoJSON conversion and preprocessing
 import clip from './clip.js';                   // stripe clipping algorithm
 import wrap from './wrap.js';                   // date line processing
 import transform from './transform.js';         // coordinate transformation

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 
-import convert from './convert';     // GeoJSON conversion and preprocessing
-import clip from './clip';           // stripe clipping algorithm
-import wrap from './wrap';           // date line processing
-import transform from './transform'; // coordinate transformation
-import createTile from './tile';     // final simplified tile generation
+import convert from './convert';             // GeoJSON conversion and preprocessing
+import defaultProjectPoint from './convert'; // GeoJSON conversion and preprocessing
+import clip from './clip';                   // stripe clipping algorithm
+import wrap from './wrap';                   // date line processing
+import transform from './transform';         // coordinate transformation
+import createTile from './tile';             // final simplified tile generation
 
 export default function geojsonvt(data, options) {
     return new GeoJSONVT(data, options);
@@ -54,7 +55,8 @@ GeoJSONVT.prototype.options = {
     lineMetrics: false,     // whether to calculate line metrics
     promoteId: null,        // name of a feature property to be promoted to feature.id
     generateId: false,      // whether to generate feature ids. Cannot be used with promoteId
-    debug: 0                // logging level (0, 1 or 2)
+	debug: 0,               // logging level (0, 1 or 2)
+	projectPoint: defaultProjectPoint // projection function
 };
 
 GeoJSONVT.prototype.splitTile = function (features, z, x, y, cz, cx, cy) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 
-import convert, { defaultProjectPoint } from './convert.js'; // GeoJSON conversion and preprocessing
+import convert, {defaultX, defaultY} from './convert.js'; // GeoJSON conversion and preprocessing
 import clip from './clip.js';                   // stripe clipping algorithm
 import wrap from './wrap.js';                   // date line processing
 import transform from './transform.js';         // coordinate transformation
@@ -16,7 +16,8 @@ const defaultOptions = {
     promoteId: null,        // name of a feature property to be promoted to feature.id
     generateId: false,      // whether to generate feature ids. Cannot be used with promoteId
     debug: 0,               // logging level (0, 1 or 2)
-    projectPoint: defaultProjectPoint // projection function
+    projectX: defaultX,     // projection function x
+    projectY: defaultY      // projection function y
 };
 
 class GeoJSONVT {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 
-import convert from './convert.js';             // GeoJSON conversion and preprocessing
-import defaultProjectPoint from './convert.js'; // GeoJSON conversion and preprocessing
+import { convert, defaultProjectPoint } from './convert.js'; // GeoJSON conversion and preprocessing
 import clip from './clip.js';                   // stripe clipping algorithm
 import wrap from './wrap.js';                   // date line processing
 import transform from './transform.js';         // coordinate transformation
@@ -16,8 +15,8 @@ const defaultOptions = {
     lineMetrics: false,     // whether to calculate line metrics
     promoteId: null,        // name of a feature property to be promoted to feature.id
     generateId: false,      // whether to generate feature ids. Cannot be used with promoteId
-	debug: 0,               // logging level (0, 1 or 2)
-	projectPoint: defaultProjectPoint // projection function
+    debug: 0,               // logging level (0, 1 or 2)
+    projectPoint: defaultProjectPoint // projection function
 };
 
 class GeoJSONVT {


### PR DESCRIPTION
This is what I used to make geojson-vt work with OpenLayers in Plate Carrée (EPSG:32663) projection:
proj4.defs("EPSG:32663", '+proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs');
