### PR TITLE
add clamp for lats beyond +/-90

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -139,6 +139,5 @@ function projectY(y) {
     const clampedY = y < -90 ? -90 : y > 90 ? 90 : y;
     const sin = Math.sin(clampedY * Math.PI / 180);
     const y2 = 0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI;
-    const clamped = y2 < 0 ? 0 : y2 > 1 ? 1 : y2;
-    return clamped
+    return y2
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -136,7 +136,9 @@ function projectX(x) {
 }
 
 function projectY(y) {
-    const sin = Math.sin(y * Math.PI / 180);
+    const clampedY = y < -90 ? -90 : y > 90 ? 90 : y;
+    const sin = Math.sin(clampedY * Math.PI / 180);
     const y2 = 0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI;
-    return y2 < 0 ? 0 : y2 > 1 ? 1 : y2;
+    const clamped = y2 < 0 ? 0 : y2 > 1 ? 1 : y2;
+    return clamped
 }


### PR DESCRIPTION
This PR assumes that expected behavior for features outside -90 ~ 90 latitude will be clamped at the respective extrema -- visually, that would be at the top and bottom edges of the map.

Without this clamp, the enclosed sin function would keep oscillating continuously, causing those extreme features to project back toward the equator. 

This could also be one-lined by clamping the incoming y to Mercator +/- 85.05, though keeping separate for clarity