### PR TITLE
misc minor updates

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -98,9 +98,7 @@ function convertLine(ring, out, tolerance, isPolygon) {
         const x = projectX(ring[j][0]);
         const y = projectY(ring[j][1]);
 
-        out.push(x);
-        out.push(y);
-        out.push(0);
+        out.push(x, y, 0);
 
         if (j > 0) {
             if (isPolygon) {

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,7 +1,7 @@
 
 export default function createFeature(id, type, geom, tags) {
     const feature = {
-        id: typeof id === 'undefined' ? null : id,
+        id: id == null ? null : id,
         type,
         geometry: geom,
         tags,
@@ -21,16 +21,19 @@ function calcBBox(feature) {
     if (type === 'Point' || type === 'MultiPoint' || type === 'LineString') {
         calcLineBBox(feature, geom);
 
-    } else if (type === 'Polygon' || type === 'MultiLineString') {
+    } else if (type === 'Polygon') {
+        // the outer ring (ie [0]) contains all inner rings
+        calcLineBBox(feature, geom[0]);
+
+    } else if (type === 'MultiLineString') {
         for (const line of geom) {
             calcLineBBox(feature, line);
         }
 
     } else if (type === 'MultiPolygon') {
         for (const polygon of geom) {
-            for (const line of polygon) {
-                calcLineBBox(feature, line);
-            }
+            // the outer ring (ie [0]) contains all inner rings
+            calcLineBBox(feature, polygon[0]);
         }
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ function GeoJSONVT(data, options) {
     if (options.maxZoom < 0 || options.maxZoom > 24) throw new Error('maxZoom should be in the 0-24 range');
     if (options.promoteId && options.generateId) throw new Error('promoteId and generateId cannot be used together.');
 
+    // projects and adds simplification info
     let features = convert(data, options);
 
     this.tiles = {};
@@ -32,6 +33,7 @@ function GeoJSONVT(data, options) {
         this.total = 0;
     }
 
+    // wraps features (ie extreme west and extreme east)
     features = wrap(features, options);
 
     // start slicing from the top tile down


### PR DESCRIPTION
The only significant change is to compute the bbox only for the outer rings of polygons - inner rings re contained into the outer and do not change the bbox.
This could speed up computation for (multi-)polygons with holes.   