### PR TITLE
Expose clip, transform and createTile

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,12 @@ export default function geojsonvt(data, options) {
     return new GeoJSONVT(data, options);
 }
 
+// Export util functions
+geojsonvt.clip = clip;
+geojsonvt.transform = transform;
+geojsonvt.createTile = createTile;
+geojsonvt.toID = toID;
+
 function GeoJSONVT(data, options) {
     options = this.options = extend(Object.create(this.options), options);
 


### PR DESCRIPTION
I would like to propose this change to expose more functions.

They have been added as `geojsonvt` properties to avoid breaking existing user of this code.

My use case: I'm working on a serverless mvt server. When a tile is requested I need to clip the ancestor tile (previously generated and dumped to disk), clip it, create a tile and transform it.

If this is not acceptable I could also maintain my own fork, let me know.
Thanks.