### PR TITLE
Added .js extension to import statments with relative paths

### DIFF
--- a/src/clip.js
+++ b/src/clip.js
@@ -1,5 +1,5 @@
 
-import createFeature from './feature';
+import createFeature from './feature.js';
 
 /* clip features between two vertical or horizontal axis-parallel lines:
  *     |        |

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,6 +1,6 @@
 
-import simplify from './simplify';
-import createFeature from './feature';
+import simplify from './simplify.js';
+import createFeature from './feature.js';
 
 // converts GeoJSON feature into an intermediate projected JSON vector format with simplification data
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 
-import convert from './convert';     // GeoJSON conversion and preprocessing
-import clip from './clip';           // stripe clipping algorithm
-import wrap from './wrap';           // date line processing
-import transform from './transform'; // coordinate transformation
-import createTile from './tile';     // final simplified tile generation
+import convert from './convert.js';     // GeoJSON conversion and preprocessing
+import clip from './clip.js';           // stripe clipping algorithm
+import wrap from './wrap.js';           // date line processing
+import transform from './transform.js'; // coordinate transformation
+import createTile from './tile.js';     // final simplified tile generation
 
 export default function geojsonvt(data, options) {
     return new GeoJSONVT(data, options);

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,6 +1,6 @@
 
-import clip from './clip';
-import createFeature from './feature';
+import clip from './clip.js';
+import createFeature from './feature.js';
 
 export default function wrap(features, options) {
     const buffer = options.buffer / options.extent;

--- a/test/test-clip.js
+++ b/test/test-clip.js
@@ -1,6 +1,6 @@
 
 import test from 'tape';
-import clip from '../src/clip';
+import clip from '../src/clip.js';
 
 /*eslint comma-spacing:0*/
 

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -2,7 +2,7 @@
 import test from 'tape';
 import fs from 'fs';
 import path from 'path';
-import geojsonvt from '../src/index';
+import geojsonvt from '../src/index.js';
 
 testTiles('us-states.json', 'us-states-tiles.json', {indexMaxZoom: 7, indexMaxPoints: 200});
 testTiles('dateline.json', 'dateline-tiles.json', {indexMaxZoom: 0, indexMaxPoints: 10000});

--- a/test/test-get-tile.js
+++ b/test/test-get-tile.js
@@ -2,7 +2,7 @@
 import test from 'tape';
 import fs from 'fs';
 import path from 'path';
-import geojsonvt from '../src/index';
+import geojsonvt from '../src/index.js';
 
 const square = [{
     geometry: [[[-64, 4160], [-64, -64], [4160, -64], [4160, 4160], [-64, 4160]]],

--- a/test/test-multi-world.js
+++ b/test/test-multi-world.js
@@ -1,6 +1,6 @@
 
 import test from 'tape';
-import geojsonvt from '../src/index';
+import geojsonvt from '../src/index.js';
 
 const leftPoint = {
     type: 'Feature',

--- a/test/test-simplify.js
+++ b/test/test-simplify.js
@@ -1,5 +1,5 @@
 
-import simplify from '../src/simplify';
+import simplify from '../src/simplify.js';
 import test from 'tape';
 
 /*eslint comma-spacing:0, no-shadow: 0*/


### PR DESCRIPTION
This is related to issue #137.
It adds file extensions to some import statements so that the code can be imported as bare modules. 