### PR TITLE
fix:  while three point in a line and the second point is in the dividing line of the tile will have problem

### DIFF
--- a/src/clip.js
+++ b/src/clip.js
@@ -116,13 +116,13 @@ function clipLine(geom, newGeom, k1, k2, axis, isPolygon, trackMetrics) {
 
         if (a < k1) {
             // ---|-->  | (line enters the clip region from the left)
-            if (b > k1) {
+            if (b >= k1) {
                 t = intersect(slice, ax, ay, bx, by, k1);
                 if (trackMetrics) slice.start = len + segLen * t;
             }
         } else if (a > k2) {
             // |  <--|--- (line enters the clip region from the right)
-            if (b < k2) {
+            if (b <= k2) {
                 t = intersect(slice, ax, ay, bx, by, k2);
                 if (trackMetrics) slice.start = len + segLen * t;
             }


### PR DESCRIPTION
**Bug Fix**:  while three point in a line and the second point is in the dividing line of the tile(with buffer), then the point will be lost in particular level.