### PR TITLE
Fix promoteId crash on features with null properties

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -33,7 +33,7 @@ function convertFeature(features, geojson, options, index) {
     let geometry = [];
     let id = geojson.id;
     if (options.promoteId) {
-        id = geojson.properties[options.promoteId];
+        id = geojson.properties && geojson.properties[options.promoteId];
     } else if (options.generateId) {
         id = index || 0;
     }

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -14,6 +14,17 @@ testTiles('single-geom.json', 'single-geom-tiles.json', {indexMaxZoom: 0, indexM
 testTiles('ids.json', 'ids-promote-id-tiles.json', {indexMaxZoom: 0, promoteId: 'prop0'});
 testTiles('ids.json', 'ids-generate-id-tiles.json', {indexMaxZoom: 0, generateId: true});
 
+test('promoteId with null properties', () => {
+    // properties: null is valid GeoJSON and must not crash promoteId
+    assert.doesNotThrow(() => {
+        genTiles({
+            type: 'Feature',
+            properties: null,
+            geometry: {type: 'Point', coordinates: [0, 0]}
+        }, {promoteId: 'myid'});
+    });
+});
+
 test('throws on invalid GeoJSON', () => {
     assert.throws(() => {
         genTiles({type: 'Pologon'});


### PR DESCRIPTION
`promoteId` throws and crashes the whole `geojsonvt(...)` call when a feature has `properties: null`, which is valid GeoJSON (RFC 7946 section 3.2 allows a null `properties` member).

```js
geojsonvt({
  type: 'Feature',
  properties: null,
  geometry: {type: 'Point', coordinates: [0, 0]}
}, {promoteId: 'id'});
// TypeError: Cannot read properties of null (reading 'id')
```

A single such feature anywhere in the input produces no tiles. The other id paths already tolerate null properties: `generateId: true` works, and no id option works, so this is an inconsistency in the `promoteId` path.

## Cause

`src/convert.js` reads `geojson.properties[options.promoteId]` with no guard against a null (or absent) `properties`.

## Fix

Guard the access. `null && x` / `undefined && x` resolve to a falsy id, which is normalized to no id downstream (the same result as a missing property key), so behavior is unchanged for features that do have properties.

## Testing

Added a test that tiles a `properties: null` feature with `promoteId`. It throws on the current code and passes with the fix. The full suite stays green (29 tests).
