### PR TITLE
fix: ignore empty polygon parts in MultiPolygon

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -67,7 +67,7 @@ function convertFeature(features, geojson, options, index) {
         for (const polygon of coords) {
             const newPolygon = [];
             convertLines(polygon, newPolygon, tolerance, true);
-            geometry.push(newPolygon);
+            if (newPolygon.length) geometry.push(newPolygon);
         }
     } else if (type === 'GeometryCollection') {
         for (const singleGeometry of geojson.geometry.geometries) {

--- a/test/test-full.js
+++ b/test/test-full.js
@@ -53,6 +53,15 @@ test('empty coordinates', () => {
     assert.deepEqual({}, genTiles(getJSON('empty-coords.json')));
 });
 
+test('empty part in a MultiPolygon', () => {
+    // should ignore an empty polygon in a MultiPolygon and tile the rest
+    const ring = [[0, 0], [10, 0], [10, 10], [0, 0]];
+    assert.deepEqual(
+        genTiles({type: 'MultiPolygon', coordinates: [[], [ring]]}),
+        genTiles({type: 'MultiPolygon', coordinates: [[ring]]})
+    );
+});
+
 function getJSON(name) {
     return JSON.parse(fs.readFileSync(new URL(`fixtures/${name}`, import.meta.url)));
 }


### PR DESCRIPTION
A `MultiPolygon` whose `coordinates` contain an empty polygon part (for example `[[], [ring]]`) throws `TypeError: Cannot read properties of undefined (reading 'length')` while building the feature bounding box, because `createFeature` reads `polygon[0]` on the empty part. A single such part in an otherwise valid `FeatureCollection` aborts the whole index build, so no tiles are produced.

This skips empty polygon parts during conversion, matching the `if (newPolygon.length)` guard already used in `clip.js`, so the valid parts still get tiled. Adds a test that fails on `main` with the `TypeError` and passes with the fix.
